### PR TITLE
[graphql-codegen] Change .cache folder to node_modules folder

### DIFF
--- a/packages/gatsby-plugin-graphql-codegen/src/graphql-codegen.config.ts
+++ b/packages/gatsby-plugin-graphql-codegen/src/graphql-codegen.config.ts
@@ -25,7 +25,7 @@ const createConfig: CreateConfig = async ({ directory, fileName, reporter }) => 
     // documents
     const docPromises = [
       './src/**/*.{ts,tsx}',
-      './.cache/fragments/*.js',
+      './node_modules/gatsby-*/**/*.js',
     ].map(async docGlob => {
       const _docGlob = path.join(directory, docGlob)
       return loadDocuments(_docGlob).catch(err => {


### PR DESCRIPTION
Since [this PR](https://github.com/gatsbyjs/gatsby/pull/19933), some plugins removed the copying to the `.cache` folder as Gatsby now look up in the `node_modules` folder. As advised [here](https://graphql-code-generator.com/docs/integrations/gatsby), I think we should add `./node_modules/gatsby-*/**/*.js` in the `documents` paths.