### PR TITLE
Export Fragment Subtypes

### DIFF
--- a/packages/gatsby-plugin-graphql-codegen/src/graphql-codegen.config.ts
+++ b/packages/gatsby-plugin-graphql-codegen/src/graphql-codegen.config.ts
@@ -61,6 +61,7 @@ const createConfig: CreateConfig = async ({
         {
           typescriptOperation: {
             skipTypename: true,
+            exportFragmentSpreadSubTypes: true,
           },
         },
       ],


### PR DESCRIPTION
closes #54 

I tried to create a unit test for this, but since `loadDocuments` is mocked, I was unable to find a way to access the real version to load real fragments and queries and check the types snapshot, and unfortunately I ran out of time.