### PR TITLE
graphql peerDependency configuration for yarn2 compatibility

### DIFF
--- a/packages/gatsby-plugin-graphql-codegen/package.json
+++ b/packages/gatsby-plugin-graphql-codegen/package.json
@@ -36,11 +36,6 @@
     "typescript": "^3.7.5",
     "graphql": "^14.6.0"
   },
-  "peerDependenciesMeta": {
-    "graphql": {
-      "optional": true
-    }
-  },
   "devDependencies": {
     "@types/fs-extra": "^7.0.0",
     "@types/lodash.debounce": "^4.0.6",

--- a/packages/gatsby-plugin-graphql-codegen/package.json
+++ b/packages/gatsby-plugin-graphql-codegen/package.json
@@ -33,8 +33,14 @@
   },
   "peerDependencies": {
     "gatsby": "^2.9.2",
-    "typescript": "^3.7.5"
+    "typescript": "^3.7.5",
+    "graphql": "^14.6.0"
   },
+  "peerDependenciesMeta": {
+		"graphql": {
+			"optional": true
+		}
+	},
   "devDependencies": {
     "@types/fs-extra": "^7.0.0",
     "@types/lodash.debounce": "^4.0.6",

--- a/packages/gatsby-plugin-graphql-codegen/package.json
+++ b/packages/gatsby-plugin-graphql-codegen/package.json
@@ -37,10 +37,10 @@
     "graphql": "^14.6.0"
   },
   "peerDependenciesMeta": {
-		"graphql": {
-			"optional": true
-		}
-	},
+    "graphql": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@types/fs-extra": "^7.0.0",
     "@types/lodash.debounce": "^4.0.6",

--- a/packages/gatsby-plugin-ts/package.json
+++ b/packages/gatsby-plugin-ts/package.json
@@ -26,7 +26,13 @@
   },
   "peerDependencies": {
     "gatsby": "^2.9.2",
-    "typescript": "^3.7.5"
+    "typescript": "^3.7.5",
+    "graphql": "^14.6.0"
+  },
+  "peerDependenciesMeta": {
+    "graphql": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@types/fs-extra": "^7.0.0",


### PR DESCRIPTION
When using yarn-pnp, Gatsby will fail if `graphql` is not defined as a peer dependency for `gatsby-plugin-ts`.  Since `codegen` is optional, I also made `graphql` an **optional** peer dependency (yarn2 specific).

I also defined `graphql` as a peer dependency for `gatsby-plugin-graphql-codegen`, since, well, it is.

I didn't see any particular `graphql` version requirement, so I just went with what was being used in my Gatsby project.  Not sure if that should be different 🤷‍♂ 