### PR TITLE
simplify github workflows

### DIFF
--- a/.github/workflows/build-starters.yml
+++ b/.github/workflows/build-starters.yml
@@ -1,21 +1,15 @@
 name: Build Starters
 
-on: [push]
+on: [pull_request]
 
 jobs:
   build:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [12.x]
-
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 12.x
 
       - name: Get yarn cache
         id: yarn-cache
@@ -27,7 +21,7 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-            
+
       - run: yarn install
       - run: yarn bootstrap
       - run: yarn workspace gatsby-plugin-graphql-codegen build
@@ -35,5 +29,5 @@ jobs:
       - run: yarn workspace gatsby-starter-ts build
         env:
           GATSBY_TELEMETRY_DISABLED: 1
-          CI: "true"
+          CI: true
       - run: yarn confirm

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -1,35 +1,28 @@
 name: Unit Tests
 
-on: [push]
+on: [pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [12.x]
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
 
-    - name: Get yarn cache
-      id: yarn-cache
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Get yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
 
-    - uses: actions/cache@v1
-      with:
-        path: ${{ steps.yarn-cache.outputs.dir }}
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
-          
-    - run: yarn install
-    - run: yarn test
-      env:
-        CI: true
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - run: yarn install
+      - run: yarn test
+        env:
+          CI: true

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -3,7 +3,7 @@ name: Unit Tests
 on: [pull_request]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,21 +1,15 @@
 name: Lint
 
-on: [push]
+on: [pull_request]
 
 jobs:
   build:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [12.x]
-
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 12.x
 
       - name: Get yarn cache
         id: yarn-cache
@@ -27,6 +21,6 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-            
+
       - run: yarn install
       - run: yarn lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: Lint
 on: [pull_request]
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Simplifies the github actions a bit. Mostly just removes the build  matrix and changes it so that it runs on pull request.

Note: after merging, we should update the required status check from `build (12.x)` to just `build`.

![image](https://user-images.githubusercontent.com/10551026/75641630-e208ad00-5c06-11ea-99eb-8df4d7e0975c.png)

i.e. that last required check should be changed to the first
