### PR TITLE
Added pluckConfig option

### DIFF
--- a/packages/gatsby-plugin-graphql-codegen/readme.md
+++ b/packages/gatsby-plugin-graphql-codegen/readme.md
@@ -27,6 +27,7 @@ module.exports = {
 |options.documentPaths| <pre>['./src/&ast;&ast;/&ast;.{ts,tsx}',<br/>'./.cache/fragments/&ast;.js', <br/>'./node_modules/gatsby-&ast;/&ast;&ast;/&ast;.js']</pre> | The paths to files containing graphql queries. <br/><small>⚠️ The default paths will be overwritten by the `documentPaths` you pass in, so please make sure to include *all* necessary paths ⚠️</small>
 |options.fileName| `graphql-type.ts` | path to the generated file. By default, it's placed at the project root directory & it should not be placed into `src`, since this will create an infinite loop|
 |options.codegenDelay| `200` | amount of delay from file change to codegen|
+|options.pluckConfig| <pre>{ globalGqlIdentifierName: "graphql", modules: [ { name: 'gatsby', identifier: 'graphql' } ] }</pre> | options passed to https://www.npmjs.com/package/graphql-tag-pluck when extracting queries and fragments from documents |
 
 An example setup:
 

--- a/packages/gatsby-plugin-graphql-codegen/readme.md
+++ b/packages/gatsby-plugin-graphql-codegen/readme.md
@@ -42,6 +42,13 @@ An example setup:
       './node_modules/gatsby-*/**/*.js',
     ],
     codegenDelay: 200,
+    pluckConfig: {
+      // this is the default config
+      globalGqlIdentifierName: 'graphql',
+      modules: [
+        { name: 'gatsby', identifier: 'graphql' },
+      ],
+    },
   }
 },
 ```

--- a/packages/gatsby-plugin-graphql-codegen/src/gatsby-node.test.js
+++ b/packages/gatsby-plugin-graphql-codegen/src/gatsby-node.test.js
@@ -58,23 +58,14 @@ it('calls `generateWithConfig` from `graphql-codegen.config.ts`', async () => {
           "./example-document-paths",
         ],
         "fileName": "./example-filename.ts",
-        "pluginOptions": Object {
-          "codegen": true,
-          "codegenDelay": 200,
-          "documentPaths": Array [
-            "./example-document-paths",
+        "pluckConfig": Object {
+          "globalGqlIdentifierName": "graphql",
+          "modules": Array [
+            Object {
+              "identifier": "graphql",
+              "name": "gatsby",
+            },
           ],
-          "fileName": "./example-filename.ts",
-          "pluckConfig": Object {
-            "globalGqlIdentifierName": "graphql",
-            "modules": Array [
-              Object {
-                "identifier": "graphql",
-                "name": "gatsby",
-              },
-            ],
-          },
-          "plugins": Array [],
         },
         "reporter": Object {
           "info": [MockFunction] {

--- a/packages/gatsby-plugin-graphql-codegen/src/gatsby-node.test.js
+++ b/packages/gatsby-plugin-graphql-codegen/src/gatsby-node.test.js
@@ -58,6 +58,24 @@ it('calls `generateWithConfig` from `graphql-codegen.config.ts`', async () => {
           "./example-document-paths",
         ],
         "fileName": "./example-filename.ts",
+        "pluginOptions": Object {
+          "codegen": true,
+          "codegenDelay": 200,
+          "documentPaths": Array [
+            "./example-document-paths",
+          ],
+          "fileName": "./example-filename.ts",
+          "pluckConfig": Object {
+            "globalGqlIdentifierName": "graphql",
+            "modules": Array [
+              Object {
+                "identifier": "graphql",
+                "name": "gatsby",
+              },
+            ],
+          },
+          "plugins": Array [],
+        },
         "reporter": Object {
           "info": [MockFunction] {
             "calls": Array [

--- a/packages/gatsby-plugin-graphql-codegen/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-graphql-codegen/src/gatsby-node.ts
@@ -1,12 +1,14 @@
 import { GatsbyNode, PluginOptions } from 'gatsby'
 import { generateWithConfig } from './graphql-codegen.config'
 import debounce from 'lodash.debounce'
+import { GraphQLTagPluckOptions } from '@graphql-toolkit/graphql-tag-pluck'
 
 export interface TsOptions extends PluginOptions {
   documentPaths?: string[]
   fileName?: string
   codegen?: boolean
   codegenDelay?: number
+  pluckConfig?: GraphQLTagPluckOptions
 }
 
 const defaultOptions: Required<TsOptions> = {
@@ -19,6 +21,15 @@ const defaultOptions: Required<TsOptions> = {
   fileName: 'graphql-types.ts',
   codegen: true,
   codegenDelay: 200,
+  pluckConfig: {
+    globalGqlIdentifierName: 'graphql',
+    modules: [
+      {
+        name: 'gatsby',
+        identifier: 'graphql',
+      },
+    ],
+  },
 }
 
 type GetOptions = (options: TsOptions) => Required<TsOptions>
@@ -43,6 +54,7 @@ export const onPostBootstrap: NonNullable<GatsbyNode['onPostBootstrap']> = async
     directory,
     fileName,
     reporter,
+    pluginOptions: options,
   })
 
   const build = async (schema: any): Promise<void> => {

--- a/packages/gatsby-plugin-graphql-codegen/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-graphql-codegen/src/gatsby-node.ts
@@ -45,7 +45,7 @@ export const onPostBootstrap: NonNullable<GatsbyNode['onPostBootstrap']> = async
   const options = getOptions(pluginOptions)
   if (!options.codegen) return
 
-  const { documentPaths, fileName, codegenDelay } = options
+  const { documentPaths, fileName, codegenDelay, pluckConfig } = options
 
   const { schema, program } = store.getState()
   const { directory } = program
@@ -54,7 +54,7 @@ export const onPostBootstrap: NonNullable<GatsbyNode['onPostBootstrap']> = async
     directory,
     fileName,
     reporter,
-    pluginOptions: options,
+    pluckConfig,
   })
 
   const build = async (schema: any): Promise<void> => {

--- a/packages/gatsby-plugin-graphql-codegen/src/graphql-codegen.config.test.js
+++ b/packages/gatsby-plugin-graphql-codegen/src/graphql-codegen.config.test.js
@@ -24,6 +24,7 @@ it('takes in options and returns a function that runs codegen for the schema', a
     documentPaths: ['./src/**/*.{ts,tsx}'],
     fileName: 'example-types.ts',
     reporter: mockReporter,
+    pluginOptions: {},
   })
 
   const mockSchema = buildSchema(`
@@ -128,6 +129,7 @@ it('calls `reporter.warn` when `loadDocuments` rejects', async () => {
     documentPaths: ['./src/**/*.{ts,tsx}'],
     fileName: 'example-types.ts',
     reporter: mockReporter,
+    pluginOptions: {},
   })
 
   const mockSchema = buildSchema(`

--- a/packages/gatsby-plugin-graphql-codegen/src/graphql-codegen.config.ts
+++ b/packages/gatsby-plugin-graphql-codegen/src/graphql-codegen.config.ts
@@ -8,6 +8,7 @@ import { codegen } from '@graphql-codegen/core'
 import { printSchema, parse } from 'gatsby/graphql'
 import { plugin as typescriptPlugin } from '@graphql-codegen/typescript'
 import { plugin as operationsPlugin } from '@graphql-codegen/typescript-operations'
+import { TsOptions } from './gatsby-node'
 
 function isSource(result: void | Source[]): result is Source[] {
   return typeof result !== 'undefined'
@@ -17,7 +18,8 @@ interface IInitialConfig {
   documentPaths: string[]
   directory: string
   fileName: string
-  reporter: Reporter
+  reporter: Reporter,
+  pluginOptions: TsOptions
 }
 
 type CreateConfigFromSchema = (schema: any) => Promise<any>
@@ -27,6 +29,7 @@ const createConfig: CreateConfig = async ({
   directory,
   fileName,
   reporter,
+  pluginOptions,
 }) => {
   // file name & location
   const pathToFile = path.join(directory, fileName)
@@ -38,6 +41,7 @@ const createConfig: CreateConfig = async ({
     const docPromises = documentPaths.map(async docGlob => {
       const _docGlob = path.join(directory, docGlob)
       return loadDocuments(_docGlob, {
+        pluckConfig: pluginOptions.pluckConfig,
         loaders: [new CodeFileLoader()],
       }).catch(err => {
         reporter.warn('[gatsby-plugin-graphql-codegen] ' + err.message)

--- a/packages/gatsby-plugin-graphql-codegen/src/graphql-codegen.config.ts
+++ b/packages/gatsby-plugin-graphql-codegen/src/graphql-codegen.config.ts
@@ -8,7 +8,7 @@ import { codegen } from '@graphql-codegen/core'
 import { printSchema, parse } from 'gatsby/graphql'
 import { plugin as typescriptPlugin } from '@graphql-codegen/typescript'
 import { plugin as operationsPlugin } from '@graphql-codegen/typescript-operations'
-import { TsOptions } from './gatsby-node'
+import { GraphQLTagPluckOptions } from '@graphql-toolkit/graphql-tag-pluck'
 
 function isSource(result: void | Source[]): result is Source[] {
   return typeof result !== 'undefined'
@@ -19,7 +19,7 @@ interface IInitialConfig {
   directory: string
   fileName: string
   reporter: Reporter,
-  pluginOptions: TsOptions
+  pluckConfig: GraphQLTagPluckOptions
 }
 
 type CreateConfigFromSchema = (schema: any) => Promise<any>
@@ -29,7 +29,7 @@ const createConfig: CreateConfig = async ({
   directory,
   fileName,
   reporter,
-  pluginOptions,
+  pluckConfig,
 }) => {
   // file name & location
   const pathToFile = path.join(directory, fileName)
@@ -41,7 +41,7 @@ const createConfig: CreateConfig = async ({
     const docPromises = documentPaths.map(async docGlob => {
       const _docGlob = path.join(directory, docGlob)
       return loadDocuments(_docGlob, {
-        pluckConfig: pluginOptions.pluckConfig,
+        pluckConfig,
         loaders: [new CodeFileLoader()],
       }).catch(err => {
         reporter.warn('[gatsby-plugin-graphql-codegen] ' + err.message)

--- a/packages/gatsby-plugin-ts/readme.md
+++ b/packages/gatsby-plugin-ts/readme.md
@@ -80,7 +80,11 @@ An example setup:
     codegenDelay: 250,
     typeCheck: false,
     pluckConfig: {
-        
+      // this is the default config
+      globalGqlIdentifierName: 'graphql',
+      modules: [
+        { name: 'gatsby', identifier: 'graphql' },
+      ],
     },
   }
 },

--- a/packages/gatsby-plugin-ts/readme.md
+++ b/packages/gatsby-plugin-ts/readme.md
@@ -60,6 +60,7 @@ In order for this plugin to work right, you'd need to set your compile options l
 |options.documentPaths| <pre>['./src/&ast;&ast;/&ast;.{ts,tsx}',<br/>'./.cache/fragments/&ast;.js', <br/>'./node_modules/gatsby-&ast;/&ast;&ast;/&ast;.js']</pre> | The paths to files containing graphql queries. <br/><small>⚠️ The default paths will be overwritten by the `documentPaths` you pass in, so please make sure to include *all* necessary paths ⚠️</small>
 |options.fileName| `graphql-type.ts` | path to the generated file. By default, it's placed at the project root directory & it should not be placed into `src`, since this will create an infinite loop|
 |options.codegenDelay| `200` | amount of delay from file change to codegen|
+|options.pluckConfig| {} | options passed to https://www.npmjs.com/package/graphql-tag-pluck when extracting queries and fragments from documents |
 
 An example setup:
 
@@ -78,6 +79,9 @@ An example setup:
     codegen: true,
     codegenDelay: 250,
     typeCheck: false,
+    pluckConfig: {
+        
+    },
   }
 },
 ```

--- a/packages/gatsby-plugin-ts/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-ts/src/gatsby-node.ts
@@ -4,6 +4,7 @@ import * as tsloader from 'ts-loader'
 import FTCWebpackPlugin from 'fork-ts-checker-webpack-plugin'
 import { onPostBootstrap as onPostBootstrapCodegen } from 'gatsby-plugin-graphql-codegen/gatsby-node'
 import requireResolve from './require-resolve'
+import { GraphQLTagPluckOptions } from '@graphql-toolkit/graphql-tag-pluck'
 
 export interface TsOptions extends PluginOptions {
   tsLoader?: Partial<tsloader.Options>
@@ -12,7 +13,8 @@ export interface TsOptions extends PluginOptions {
   forkTsCheckerPlugin?: Partial<FTCWebpackPlugin.Options>
   fileName?: string
   codegen?: boolean
-  codegenDelay?: number
+  codegenDelay?: number,
+  pluckConfig?: GraphQLTagPluckOptions
 }
 
 const defaultOptions: TsOptions = {
@@ -24,6 +26,15 @@ const defaultOptions: TsOptions = {
   fileName: 'graphql-types.ts',
   codegen: true,
   codegenDelay: 200,
+  pluckConfig: {
+    globalGqlIdentifierName: 'graphql',
+    modules: [
+      {
+        name: 'gatsby',
+        identifier: 'graphql',
+      },
+    ],
+  },
 }
 
 type GetOptions = (options: TsOptions) => TsOptions


### PR DESCRIPTION
Added pluckConfig option to gatsby-plugin-ts and gatsby-plugin-graphql-codegen, to allow the user of the plugin to specify wich queries and fragments in documents should be processed. Default options are set so that by default only query using the `graphql` tag from gatsby are processed (breaking change) 

Also related to: https://github.com/d4rekanguok/gatsby-typescript/issues/39

See also: https://www.npmjs.com/package/graphql-tag-pluck and https://graphql-code-generator.com/docs/getting-started/codegen-config