### PR TITLE
:pencil2: (fix typo)

### DIFF
--- a/packages/gatsby-plugin-ts/readme.md
+++ b/packages/gatsby-plugin-ts/readme.md
@@ -39,7 +39,7 @@ In order for this plugin to work right, you'd need to set your compile options l
     "moduleResolution": "node", /* <-- required! */
 
     /* for mixed ts/js codebase */
-    "allowJS": true,
+    "allowJs": true,
     "outDir": "./build"    /* this won't be used by ts-loader */
     /* other options... */
   }

--- a/readme.md
+++ b/readme.md
@@ -174,7 +174,7 @@ Here's a list of common questions I've seen since releasing this project. If you
   You'd have to update your `tsconfig` with the below options:
 
   ```json
-    "allowJS": true,
+    "allowJs": true,
     "outDir": "./build"
   ```
 


### PR DESCRIPTION
allowJS → allowJs

### reference
https://www.typescriptlang.org/tsconfig#allowJs