### PR TITLE
update(docs): Remove trailing comma from package.json example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -273,7 +273,7 @@ Gatsby recently moved plugins' fragments from `.cache` to `node_modules`. We cur
   "workspaces": {
     "packages": ["packages/*"],
     "nohoist": [
-      "**/gatsby-transformer-sharp",
+      "**/gatsby-transformer-sharp"
     ]
   }
   ```


### PR DESCRIPTION
As title, found this in the [FAQ,](https://github.com/d4rekanguok/gatsby-typescript#common-warning--errors) tried to copy it in but it failed because of the trailing comma

Hoping to save others time by putting this up.