### PR TITLE
fix: rollback @graphql-tools/url-loader to version w/o exp features (#142)

### DIFF
--- a/packages/gatsby-plugin-graphql-codegen/package.json
+++ b/packages/gatsby-plugin-graphql-codegen/package.json
@@ -30,7 +30,7 @@
     "@graphql-tools/graphql-tag-pluck": "^7.0.0",
     "@graphql-tools/json-file-loader": "^7.0.0",
     "@graphql-tools/load": "^7.0.0",
-    "@graphql-tools/url-loader": "^7.0.0",
+    "@graphql-tools/url-loader": "7.0.0 - 7.4.2",
     "@graphql-tools/utils": "^8.0.0",
     "fs-extra": "^10.0.0",
     "lodash.debounce": "4.0.8"


### PR DESCRIPTION
Please see #142 for more information on this PR. To summarize, newer versions of the `@graphql-tools/url-loader` (`>7.4.2`) use experimental features that generate errors while `gatsby-plugin-graphql-codegen` runs. Rolling back to `7.4.2` of `url-loader` is recommended until this module resolves the issues stemming from the use of experimental features.